### PR TITLE
Fix all 4 Dependabot alerts (npm audit 27 → 0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "~5.6.2"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@11ty/gray-matter": {
@@ -6291,10 +6291,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.7",
@@ -6460,13 +6463,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7094,12 +7099,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -16659,15 +16658,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17905,12 +17895,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -19461,12 +19451,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,13 @@
     "@docusaurus/types": "^3.10.2",
     "typescript": "~5.6.2"
   },
+  "overrides": {
+    "brace-expansion": "^5.0.8",
+    "serialize-javascript": "^7.0.5",
+    "sockjs": {
+      "uuid": "^11.1.1"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
Small, independent of #27. `npm audit` goes from **27 findings to 0**.

## The alerts

All four trace to three transitive build-tooling packages. None ships to the browser.

| Package | Was | Now | Severity | Reached via |
| --- | --- | --- | --- | --- |
| `brace-expansion` | 1.1.17 | **5.0.8** | HIGH — DoS via unbounded expansion | `docusaurus-lunr-search` → `minimatch@3` |
| `serialize-javascript` | 6.0.2 | **7.0.7** | HIGH — RCE via `RegExp.flags`<br/>MED — CPU exhaustion DoS | `@docusaurus/bundler` → `copy-webpack-plugin`, `css-minimizer-webpack-plugin` |
| `uuid` | 8.3.2 | **11.1.1** | MED — missing buffer bounds check | `@docusaurus/core` → `webpack-dev-server` → `sockjs` |

## Why `overrides` and not `npm audit fix --force`

`--force` wanted to **downgrade `docusaurus-lunr-search` from 3.6.0 to 2.1.3** to satisfy the graph. That would have traded a build-time DoS for a two-major regression in the site's search.

## Why the `uuid` override is scoped

```json
"overrides": {
  "brace-expansion": "^5.0.8",
  "serialize-javascript": "^7.0.5",
  "sockjs": { "uuid": "^11.1.1" }
}
```

Two `uuid` versions are installed. A top-level `"uuid": "^11.1.1"` would have forced both and thereby **downgraded `mermaid`'s `uuid@14.0.1`**, which was never vulnerable. Scoping it to `sockjs` fixes the vulnerable instance and leaves the other alone. Verified after install:

```
@docusaurus/core > webpack-dev-server > sockjs > uuid@11.1.1   ← patched
@docusaurus/theme-mermaid > mermaid > uuid@14.0.1              ← untouched
```

`brace-expansion` and `serialize-javascript` each had a single resolved version, so a top-level override carries no downgrade risk.

## ESM compatibility checked first

These are consumed by CJS tooling, so an ESM-only bump would break the build. Checked before installing:

- `brace-expansion@5.0.8` — `type: module` but dual, with `exports.require` → CJS resolves `dist/commonjs/index.js`
- `uuid@11.1.1` — dual, `exports.node.require` → CJS resolves `dist/cjs/index.js`
- `serialize-javascript@7.0.5` — plain CJS. Declares `engines.node >=20.0.0`; `package.json` already requires `>=20.0` and `.nvmrc` pins 22

## Verified on both code paths

The two paths exercise different overrides, so both were needed:

| Path | Exercises | Result |
| --- | --- | --- |
| `npm run build` | `serialize-javascript` via the webpack plugins, `brace-expansion` via lunr globbing | clean, 46/46 documents indexed |
| `npm run start` | `webpack-dev-server` → `sockjs` → `uuid` — the **only** consumer of that override | HTTP 200, compiled successfully, 0 errors |
| `npm run typecheck` | — | clean |

## Note

Overrides pin versions the parent packages never tested against, so they are worth revisiting: each can be dropped once upstream bumps its own dependency. Left in place indefinitely they become invisible technical debt.

**#27 will need a rebase after this merges** — both touch `package.json` and `package-lock.json`. Resolving it is mechanical: take both sets of changes to `package.json`, then regenerate the lockfile.