### PR TITLE
ci: move all actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # showLastUpdateTime reads each page's last commit date, so the
           # default shallow clone would leave every timestamp wrong or absent.
@@ -36,7 +36,7 @@ jobs:
         run: python3 scripts/check-downloads.py
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload build artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docusaurus-build
           path: ./build
@@ -75,19 +75,25 @@ jobs:
       
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docusaurus-build
           path: ./build
           
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
+      # include-hidden-files restores pre-v4 behaviour: from v4 this action
+      # drops dotfiles, and the Docusaurus build emits `build/.nojekyll`.
+      # Nothing in the output is underscore-prefixed today, so losing it would
+      # not break the current site — but the deployed artifact should not
+      # quietly change contents as a side effect of a runtime bump.
       - name: Upload artifact to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./build
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v5 


### PR DESCRIPTION
Both jobs carry the deprecation annotation — the runner is force-running six actions on Node 24 because they declare `runs.using: node20`. This bumps each to the current major.

| Action | From | To | Runtime |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v7** | node24 |
| `actions/setup-node` | v4 | **v7** | node24 |
| `actions/upload-artifact` | v4 | **v7** | node24 |
| `actions/download-artifact` | v4 | **v8** | node24 |
| `actions/configure-pages` | v5 | **v6** | node24 |
| `actions/upload-pages-artifact` | v3 | **v5** | composite |
| `actions/deploy-pages` | v4 | **v5** | node24 |

## Two things that were not obvious

**The deploy job's annotation named `upload-artifact@v4`, but that job never calls it.** `upload-pages-artifact` is a *composite* action wrapping it, so the transitive version is invisible in our workflow file. Bumping the wrapper is what clears it — v5 pins `upload-artifact@v7.0.0` by SHA internally.

**`include-hidden-files: true` is required to preserve current behaviour.** `upload-pages-artifact` stopped including dotfiles at v4, and the Docusaurus build emits `build/.nojekyll`. Nothing in the output is underscore-prefixed, so the site would not actually break — but a runtime bump should not silently change what ships.

## Verified, not assumed

Release notes and actual runtime disagree here: `upload-artifact@v5` and `download-artifact@v6` both announce Node 24 support while still defaulting to `node20`. Every version in the table was confirmed by reading `runs.using` in its `action.yml` at that tag.

Breaking changes reviewed; none apply:

- **setup-node v5** auto-caching triggers on a `packageManager` field in `package.json` — absent here, and `cache: 'npm'` is set explicitly.
- **download-artifact v5** changed output paths for downloads *by ID* — we download by `name`.
- **checkout v7** blocks fork checkout for `pull_request_target` / `workflow_run` — we use `push` and `pull_request`.
- **Runner minimum** for these versions is 2.327.1; the last run used **2.337.0**.

## Test coverage caveat

A PR run exercises the **build** job only — `deploy` is gated on `github.event_name != 'pull_request'`. So `download-artifact@v8`, `configure-pages@v6`, `upload-pages-artifact@v5` and `deploy-pages@v5` are first exercised on merge to `main`. Worth watching that run rather than assuming a green PR covers it.

Local gates all pass: `check:video`, `test:files` (44), `check:downloads`, `typecheck`, `build`.

https://claude.ai/code/session_01EYx8UaJqtmxCD8ANp3SqmA
